### PR TITLE
Category tree, selected category search fix

### DIFF
--- a/source/Application/Controller/Admin/AdminDetails.php
+++ b/source/Application/Controller/Admin/AdminDetails.php
@@ -276,7 +276,7 @@ class AdminDetails extends \oxAdminView
         if ($sSelectedCatId) {
             // fixed parent category in select list
             foreach ($oCatTree as $oCategory) {
-                if ($oCategory->getId() == $sSelectedCatId) {
+                if (strcmp($oCategory->getId(), $sSelectedCatId) == 0) {
                     $oCategory->selected = 1;
                     break;
                 }


### PR DESCRIPTION
About error, in category list wrong category was selected. This was because parent category ID was '003' and other category ID was '03'. And then '==' comparison tries to compare these strings, it interprets them like a numbers. Fixed by strcmp() which checks strings in binary level.